### PR TITLE
Allow to use repo with tramp-mode

### DIFF
--- a/repo.el
+++ b/repo.el
@@ -167,7 +167,7 @@ Run SENTINEL after the process exits."
          proc)
     (with-current-buffer buffer
       (insert (format "Running repo %s\n" (mapconcat 'identity args " "))))
-    (setq proc (apply 'start-process repo-args))
+    (setq proc (apply 'start-file-process repo-args))
     (set-process-sentinel proc sentinel)
     proc))
 


### PR DESCRIPTION
According to Emacs Manual:
>   The difference of start-file-process from start-process is that this
>   function may invoke a file name handler based on the value of
>   default-directory. This handler ought to run program, perhaps on the
>   local host, perhaps on a remote host that corresponds to
>   default-directory.

Issue: #6