### PR TITLE
Fix the parsing, don't make non-generic assumptions

### DIFF
--- a/repo.el
+++ b/repo.el
@@ -272,8 +272,7 @@ PROC is the repo info process, EVENT is the sentinel event."
         (repo-status-insert status "% -23s%s\n" "Workspace:" workspace)
         (unless (re-search-backward "Running repo info -lo" nil t)
           (funcall parse-error))
-        (forward-line)
-        (unless (looking-at "^Manifest branch: \\(.*\\)$")
+        (unless (re-search-forward "^Manifest branch: \\(.*\\)$")
           (funcall parse-error))
         (repo-status-insert status "% -23s%s\n" "Manifest branch:" (match-string 1))
         (forward-line)
@@ -290,8 +289,8 @@ PROC is the repo info process, EVENT is the sentinel event."
         (while (not (looking-at "Repo process finished"))
           (repo-status-insert status "%s" (thing-at-point 'line))
           (forward-line))
-        (repo-status-setup-buffer status workspace)
-        ))))
+        (repo-status-setup-buffer status workspace)))))
+
 
 (defun repo-status-setup-buffer (buffer workspace)
   "Setup the repo status BUFFER for WORKSPACE."


### PR DESCRIPTION
This fixes a parsing error when `repo` prints the annoying message about the used version:

The content of `*repo: workspace-dir` buffer:
```
Running repo info -lo
[33m
... A new version of repo (2.40) is available.[m
[33m... New version is available at: /workspace-dir/.repo/repo/repo
... The launcher is run from: /bin/repo
!!! The launcher is not writable.  Please talk to your sysadmin or distro
!!! to get an update installed.
[m
Manifest branch: 
Manifest merge branch: refs/heads/XXXX
Manifest groups: default,platform-linux
----------------------------
Repo process finished
```

The current code **assumes** that `Manifest branch:` is under `Running repo info -lo`, it doesn't take the potential version number message into account.